### PR TITLE
feat(rtsp-fixer): offline camera thumbnail fallback

### DIFF
--- a/rtsp-fixer/Dockerfile
+++ b/rtsp-fixer/Dockerfile
@@ -1,6 +1,7 @@
 ARG BUILD_FROM=stop-complaining
 
 FROM golang:1.26.4-alpine3.24 AS go-builder
+RUN apk add --no-cache gcc musl-dev
 WORKDIR /code
 RUN go env
 

--- a/rtsp-fixer/Dockerfile
+++ b/rtsp-fixer/Dockerfile
@@ -1,6 +1,6 @@
 ARG BUILD_FROM=stop-complaining
 
-FROM golang:1.26-alpine AS go-builder
+FROM golang:1.26.4-alpine3.24 AS go-builder
 WORKDIR /code
 RUN go env
 

--- a/rtsp-fixer/Dockerfile
+++ b/rtsp-fixer/Dockerfile
@@ -1,6 +1,6 @@
 ARG BUILD_FROM=stop-complaining
 
-FROM golang:1.24.5-alpine3.22 AS go-builder
+FROM golang:1.26.1-alpine3.22 AS go-builder
 WORKDIR /code
 RUN go env
 

--- a/rtsp-fixer/Dockerfile
+++ b/rtsp-fixer/Dockerfile
@@ -1,6 +1,6 @@
 ARG BUILD_FROM=stop-complaining
 
-FROM golang:1.26.1-alpine3.22 AS go-builder
+FROM golang:1.26-alpine AS go-builder
 WORKDIR /code
 RUN go env
 

--- a/rtsp-fixer/server/pkg/proxy/server.go
+++ b/rtsp-fixer/server/pkg/proxy/server.go
@@ -93,7 +93,8 @@ func (me *server) Run(ctx context.Context) error {
 	}()
 	go func() {
 		me.logger.Infof("starting HTTP thumbnail server on %s", me.httpSrv.Addr)
-		if err := me.httpSrv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		err := me.httpSrv.ListenAndServe()
+		if err != nil && err != http.ErrServerClosed {
 			me.logger.WithError(err).Error("HTTP thumbnail server error")
 		}
 	}()

--- a/rtsp-fixer/server/pkg/proxy/thumbnails.go
+++ b/rtsp-fixer/server/pkg/proxy/thumbnails.go
@@ -64,7 +64,8 @@ func (me *server) serveThumbnail(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "image/jpeg")
-	if err := jpeg.Encode(w, thumb.thumbnail, jpegOptions); err != nil {
+	err := jpeg.Encode(w, thumb.thumbnail, jpegOptions)
+	if err != nil {
 		me.logger.WithError(err).Errorf("failed to encode thumbnail for %q", path)
 	}
 }
@@ -172,10 +173,11 @@ func (me *client) monitorUpstream() {
 				ReadTimeout:  4 * time.Second,
 				WriteTimeout: 4 * time.Second,
 			}
-			if err := probe.Start2(); err != nil {
+			err := probe.Start2()
+			if err != nil {
 				continue
 			}
-			_, _, err := probe.Describe((*base.URL)(&url))
+			_, _, err = probe.Describe((*base.URL)(&url))
 			probe.Close()
 			if err == nil {
 				me.srv.logger.Infof("stream %q came back online, closing thumbnail stream", me.path)
@@ -188,14 +190,15 @@ func (me *client) monitorUpstream() {
 }
 
 func (me *client) playThumbnailStream() (*base.Response, error) {
-	img, _ := me.srv.getThumbnail(me.path)
-	if img == nil {
+	img, err := me.srv.getThumbnail(me.path)
+	if err != nil {
 		img = image.NewRGBA(image.Rect(0, 0, 640, 480))
 	}
 	img = overlayError(img, me.thumbnailStream.originalErr)
 
 	var buf bytes.Buffer
-	if err := jpeg.Encode(&buf, img, jpegOptions); err != nil {
+	err = jpeg.Encode(&buf, img, jpegOptions)
+	if err != nil {
 		return nil, fmt.Errorf("failed to encode JPEG: %w", err)
 	}
 

--- a/rtsp-fixer/server/pkg/proxy/thumbnails.go
+++ b/rtsp-fixer/server/pkg/proxy/thumbnails.go
@@ -34,7 +34,6 @@ const (
 var jpegOptions = &jpeg.Options{Quality: 85}
 
 type thumbnailData struct {
-	ignore        bool
 	lastCapture   time.Time
 	thumbnailPath string
 	thumbnail     image.Image
@@ -46,10 +45,6 @@ func (me *server) shouldRecordThumbnail(path string) bool {
 
 	thumb, ok := me.thumbs[path]
 	if !ok {
-		return false
-	}
-
-	if thumb.ignore {
 		return false
 	}
 	return time.Since(thumb.lastCapture) >= thumbnailInterval
@@ -79,7 +74,7 @@ func (me *server) getThumbnail(path string) (image.Image, error) {
 	defer me.thumbsMutex.RUnlock()
 
 	thumb, ok := me.thumbs[path]
-	if !ok || thumb.ignore {
+	if !ok {
 		return nil, fmt.Errorf("thumbnail for %q not found", path)
 	}
 
@@ -102,17 +97,16 @@ func (me *server) saveThumbnailH264(path string, nalUnits [][]byte) {
 }
 
 func (me *server) saveThumbnailInternal(path string, getImage func() (image.Image, error)) error {
+	me.thumbsMutex.RLock()
+	thumb, ok := me.thumbs[path]
+	me.thumbsMutex.RUnlock()
+	if !ok {
+		return fmt.Errorf("thumbnail for %q not found", path)
+	}
+
 	img, err := getImage()
 	if err != nil {
 		return fmt.Errorf("failed to get image for thumbnail: %w", err)
-	}
-
-	me.thumbsMutex.Lock()
-	defer me.thumbsMutex.Unlock()
-
-	thumb, ok := me.thumbs[path]
-	if !ok {
-		return fmt.Errorf("thumbnail for %q not found", path)
 	}
 
 	tmp := thumb.thumbnailPath + ".tmp"
@@ -135,8 +129,10 @@ func (me *server) saveThumbnailInternal(path string, getImage func() (image.Imag
 	}
 
 	me.logger.Infof("thumbnail for %s saved to %s", path, thumb.thumbnailPath)
+	me.thumbsMutex.Lock()
 	thumb.thumbnail = img
 	thumb.lastCapture = time.Now()
+	me.thumbsMutex.Unlock()
 	return nil
 }
 
@@ -192,15 +188,14 @@ func (me *client) monitorUpstream() {
 }
 
 func (me *client) playThumbnailStream() (*base.Response, error) {
-	img, err := me.srv.getThumbnail(me.path)
-	if err != nil {
-		return nil, err
+	img, _ := me.srv.getThumbnail(me.path)
+	if img == nil {
+		img = image.NewRGBA(image.Rect(0, 0, 640, 480))
 	}
 	img = overlayError(img, me.thumbnailStream.originalErr)
 
 	var buf bytes.Buffer
-	err = jpeg.Encode(&buf, img, jpegOptions)
-	if err != nil {
+	if err := jpeg.Encode(&buf, img, jpegOptions); err != nil {
 		return nil, fmt.Errorf("failed to encode JPEG: %w", err)
 	}
 
@@ -213,7 +208,6 @@ func (me *client) playThumbnailStream() (*base.Response, error) {
 	go func() {
 		ticker := time.NewTicker(time.Second)
 		defer ticker.Stop()
-		pts := time.Duration(0)
 
 		for range ticker.C {
 			pkts, err := enc.Encode(jpegBytes)
@@ -226,7 +220,6 @@ func (me *client) playThumbnailStream() (*base.Response, error) {
 					return
 				}
 			}
-			pts += time.Second
 		}
 	}()
 

--- a/rtsp-fixer/server/pkg/proxy/thumbnails.go
+++ b/rtsp-fixer/server/pkg/proxy/thumbnails.go
@@ -192,6 +192,7 @@ func (me *client) monitorUpstream() {
 func (me *client) playThumbnailStream() (*base.Response, error) {
 	img, err := me.srv.getThumbnail(me.path)
 	if err != nil {
+		me.srv.logger.WithError(err).Warnf("no thumbnail for %q, using black placeholder", me.path)
 		img = image.NewRGBA(image.Rect(0, 0, 640, 480))
 	}
 	img = overlayError(img, me.thumbnailStream.originalErr)

--- a/rtsp-fixer/server/pkg/proxy/thumbnails_h264.go
+++ b/rtsp-fixer/server/pkg/proxy/thumbnails_h264.go
@@ -9,7 +9,8 @@ import (
 )
 
 func init() {
-	if err := openh264.Open(libOpenH264); err != nil {
+	err := openh264.Open(libOpenH264)
+	if err != nil {
 		panic(fmt.Sprintf("failed to load openh264: %v", err))
 	}
 }

--- a/rtsp-fixer/server/pkg/proxy/thumbnails_linux.go
+++ b/rtsp-fixer/server/pkg/proxy/thumbnails_linux.go
@@ -2,4 +2,4 @@
 
 package proxy
 
-const libOpenH264 = "libopenh264.so.2"
+const libOpenH264 = "libopenh264.so.8"


### PR DESCRIPTION
- Serve a frozen MJPEG thumbnail stream when the upstream camera is unreachable, instead of returning a gateway error
- HTTP server on port 6667 for fetching the latest thumbnail as JPEG (`/{name}`)
- Error message overlaid on the thumbnail (3× scaled, centered)
- Background goroutine monitors upstream every 10s and closes the thumbnail stream when the camera comes back
- Thumbnails persisted to disk and reloaded on startup