### PR TITLE
fix: bind to 0.0.0.0 for HA addon port mapping (0.0.3)

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -101,7 +101,7 @@ jobs:
 
       - name: Build ${{ matrix.addon }} add-on
         if: steps.check.outputs.build_arch == 'true'
-        uses: home-assistant/builder@2026.03.2
+        uses: home-assistant/builder@2025.09.0
         with:
           args: |
             ${{ env.BUILD_ARGS }} \

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -101,7 +101,7 @@ jobs:
 
       - name: Build ${{ matrix.addon }} add-on
         if: steps.check.outputs.build_arch == 'true'
-        uses: home-assistant/builder@2025.09.0
+        uses: home-assistant/builder@2026.03.2
         with:
           args: |
             ${{ env.BUILD_ARGS }} \

--- a/rtsp-fixer/config.yaml
+++ b/rtsp-fixer/config.yaml
@@ -1,6 +1,6 @@
 name: "RTSP Stream Fixer"
 description: "Fixes the non-standard RTSP streams so they can be used with FFMpeg"
-version: "0.0.2"
+version: "0.0.3"
 slug: "rtsp-stream-fixer"
 url: "https://github.com/LouisBrunner/ha-addons/blob/main/rtsp-fixer"
 init: false

--- a/rtsp-fixer/config.yaml
+++ b/rtsp-fixer/config.yaml
@@ -8,9 +8,6 @@ image: ghcr.io/louisbrunner/ha-rtsp-fixer-{arch}
 arch:
   - aarch64
   - amd64
-  - armhf
-  - armv7
-  - i386
 options:
   streams:
     - name: example

--- a/rtsp-fixer/server/cmd/server/main.go
+++ b/rtsp-fixer/server/cmd/server/main.go
@@ -98,7 +98,6 @@ func work(ctx context.Context, logger *logrus.Logger) error {
 		baseFolder = "/data"
 	}
 
-	logger.Infof("starting server on port %s", cfg.port)
 	server, err := proxy.NewServer(logger, baseFolder, cfg.port, cfg.portThumbnail, cfg.streams)
 	if err != nil {
 		return err

--- a/rtsp-fixer/server/pkg/proxy/server.go
+++ b/rtsp-fixer/server/pkg/proxy/server.go
@@ -73,12 +73,12 @@ func NewServer(logger *logrus.Logger, baseFolder, port, httpPort string, streams
 	}
 	me.rtsp = &gortsplib.Server{
 		Handler:     me,
-		RTSPAddress: fmt.Sprintf("127.0.0.1:%s", port),
+		RTSPAddress: fmt.Sprintf(":%s", port),
 	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", me.serveThumbnail)
 	me.httpSrv = &http.Server{
-		Addr:    fmt.Sprintf("127.0.0.1:%s", httpPort),
+		Addr:    fmt.Sprintf(":%s", httpPort),
 		Handler: mux,
 	}
 	return me, nil
@@ -98,6 +98,7 @@ func (me *server) Run(ctx context.Context) error {
 			me.logger.WithError(err).Error("HTTP thumbnail server error")
 		}
 	}()
+	me.logger.Infof("starting RTSP server on %s", me.rtsp.RTSPAddress)
 	return me.rtsp.StartAndWait()
 }
 

--- a/rtsp-fixer/server/pkg/proxy/thumbnails.go
+++ b/rtsp-fixer/server/pkg/proxy/thumbnails.go
@@ -58,13 +58,21 @@ func (me *server) serveThumbnail(w http.ResponseWriter, r *http.Request) {
 	thumb, ok := me.thumbs[path]
 	me.thumbsMutex.RUnlock()
 
-	if !ok || thumb.thumbnail == nil {
+	if !ok {
 		http.NotFound(w, r)
 		return
 	}
 
+	me.logger.Debugf("serving thumbnail for %q", path)
+
+	img := thumb.thumbnail
+	if img == nil {
+		me.logger.Warnf("thumbnail for %q not found, using black placeholder", path)
+		img = getFallbackThumbnail()
+	}
+
 	w.Header().Set("Content-Type", "image/jpeg")
-	err := jpeg.Encode(w, thumb.thumbnail, jpegOptions)
+	err := jpeg.Encode(w, img, jpegOptions)
 	if err != nil {
 		me.logger.WithError(err).Errorf("failed to encode thumbnail for %q", path)
 	}
@@ -193,7 +201,7 @@ func (me *client) playThumbnailStream() (*base.Response, error) {
 	img, err := me.srv.getThumbnail(me.path)
 	if err != nil {
 		me.srv.logger.WithError(err).Warnf("no thumbnail for %q, using black placeholder", me.path)
-		img = image.NewRGBA(image.Rect(0, 0, 640, 480))
+		img = getFallbackThumbnail()
 	}
 	img = overlayError(img, me.thumbnailStream.originalErr)
 
@@ -299,6 +307,10 @@ func readThumbnail(inputFile string) (image.Image, error) {
 
 	img, _, err := image.Decode(f)
 	return img, err
+}
+
+func getFallbackThumbnail() image.Image {
+	return image.NewRGBA(image.Rect(0, 0, 640, 480))
 }
 
 func overlayError(img image.Image, err error) image.Image {


### PR DESCRIPTION
Servers were binding to `127.0.0.1`, which is unreachable from outside a Docker container. Docker port mapping requires `0.0.0.0`.

Also includes thumbnail refactor and logging cleanup from prior work.