### PR TITLE
fix(ci): fork prepare/publish actions to restore {image}-{arch} naming, bump to 0.0.5

### DIFF
--- a/.github/actions/prepare-multi-arch-matrix/action.yml
+++ b/.github/actions/prepare-multi-arch-matrix/action.yml
@@ -1,3 +1,4 @@
+# Forked from https://github.com/home-assistant/builder/blob/master/actions/prepare-multi-arch-matrix/action.yml
 name: Prepare multi-arch build matrix
 description: Validate architectures and build a matrix with arch, runner OS, and full image name
 
@@ -39,6 +40,8 @@ runs:
               exit 1
               ;;
           esac
+          # FIXME: upstream uses ${arch}-${IMAGE_NAME} but HA Supervisor resolves the {arch} placeholder
+          # in config.yaml image field and expects the suffix form: ${IMAGE_NAME}-${arch}
           matrix=$(jq -c --arg arch "$arch" --arg os "$os" --arg image "${REGISTRY_PREFIX}/${IMAGE_NAME}-${arch}" \
             '.include += [{arch: $arch, os: $os, image: $image}]' <<< "${matrix}")
         done

--- a/.github/actions/prepare-multi-arch-matrix/action.yml
+++ b/.github/actions/prepare-multi-arch-matrix/action.yml
@@ -40,8 +40,7 @@ runs:
               exit 1
               ;;
           esac
-          # FIXME: upstream uses ${arch}-${IMAGE_NAME} but HA Supervisor resolves the {arch} placeholder
-          # in config.yaml image field and expects the suffix form: ${IMAGE_NAME}-${arch}
+          # FIXME: previous versions used ${IMAGE_NAME}-${arch} but the new action does the reverse, we patch it here for backwards compatibility
           matrix=$(jq -c --arg arch "$arch" --arg os "$os" --arg image "${REGISTRY_PREFIX}/${IMAGE_NAME}-${arch}" \
             '.include += [{arch: $arch, os: $os, image: $image}]' <<< "${matrix}")
         done

--- a/.github/actions/prepare-multi-arch-matrix/action.yml
+++ b/.github/actions/prepare-multi-arch-matrix/action.yml
@@ -1,0 +1,47 @@
+name: Prepare multi-arch build matrix
+description: Validate architectures and build a matrix with arch, runner OS, and full image name
+
+inputs:
+  architectures:
+    description: Architectures to build (JSON array, e.g., '["amd64", "aarch64"]')
+    required: true
+  image-name:
+    description: Image name without a tag (e.g., "base-python")
+    required: true
+  registry-prefix:
+    description: Registry and namespace prefix (e.g., "ghcr.io/owner")
+    required: false
+    default: ghcr.io/${{ github.repository_owner }}
+
+outputs:
+  matrix:
+    description: JSON matrix with arch, os, and image name for each architecture
+    value: ${{ steps.set-matrix.outputs.matrix }}
+
+runs:
+  using: composite
+  steps:
+    - name: Build matrix from architectures
+      id: set-matrix
+      shell: bash
+      env:
+        ARCHITECTURES: ${{ inputs.architectures }}
+        REGISTRY_PREFIX: ${{ inputs.registry-prefix }}
+        IMAGE_NAME: ${{ inputs.image-name }}
+      run: |
+        matrix='{"include":[]}'
+        for arch in $(jq -r '.[]' <<< "${ARCHITECTURES}"); do
+          case "${arch}" in
+            amd64)   os="ubuntu-24.04" ;;
+            aarch64) os="ubuntu-24.04-arm" ;;
+            *)
+              echo "::error::Unsupported architecture: ${arch}. Supported values: amd64, aarch64"
+              exit 1
+              ;;
+          esac
+          matrix=$(jq -c --arg arch "$arch" --arg os "$os" --arg image "${REGISTRY_PREFIX}/${IMAGE_NAME}-${arch}" \
+            '.include += [{arch: $arch, os: $os, image: $image}]' <<< "${matrix}")
+        done
+
+        echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
+        jq . <<< "${matrix}"

--- a/.github/actions/publish-multi-arch-manifest/action.yml
+++ b/.github/actions/publish-multi-arch-manifest/action.yml
@@ -1,0 +1,93 @@
+name: Publish multi-arch manifest
+description: Create a multi-arch manifest from per-architecture images and optionally sign it
+
+inputs:
+  architectures:
+    description: Architectures (JSON array, e.g., '["amd64", "aarch64"]')
+    required: true
+  container-registry:
+    description: Container registry (e.g., "ghcr.io")
+    required: false
+    default: "ghcr.io"
+  container-registry-password:
+    description: Password for container registry (use secrets.GITHUB_TOKEN for GHCR)
+    required: true
+  container-registry-username:
+    description: Username for container registry (defaults to repository owner)
+    required: false
+    default: ${{ github.repository_owner }}
+  cosign:
+    description: Whether to sign the manifest with Cosign
+    required: false
+    default: "true"
+  image-name:
+    description: Image name without a tag (e.g., "base-python")
+    required: true
+  image-tags:
+    description: Image tags, one per line (first tag is the primary tag used for per-arch image lookup)
+    required: true
+  registry-prefix:
+    description: Registry and namespace prefix (e.g., "ghcr.io/owner")
+    required: false
+    default: ghcr.io/${{ github.repository_owner }}
+
+runs:
+  using: composite
+  steps:
+    - name: Login to container registry
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+      with:
+        registry: ${{ inputs.container-registry }}
+        username: ${{ inputs.container-registry-username }}
+        password: ${{ inputs.container-registry-password }}
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+      with:
+        # TODO: remove pinning once >=v0.32.1 is available in https://github.com/actions/runner
+        version: v0.32.1
+
+    - name: Install Cosign
+      if: inputs.cosign == 'true'
+      uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+    - name: Create multi-arch manifest and sign it
+      shell: bash
+      env:
+        ARCHITECTURES: ${{ inputs.architectures }}
+        REGISTRY_PREFIX: ${{ inputs.registry-prefix }}
+        IMAGE_NAME: ${{ inputs.image-name }}
+        IMAGE_TAGS: ${{ inputs.image-tags }}
+        COSIGN: ${{ inputs.cosign }}
+      run: |
+        image_tags=()
+        while IFS= read -r tag; do
+          [[ -n "$tag" ]] && image_tags+=("${tag}")
+        done <<< "${IMAGE_TAGS}"
+
+        source_images=()
+        for arch in $(jq -r '.[]' <<< "${ARCHITECTURES}"); do
+          source_images+=("${REGISTRY_PREFIX}/${IMAGE_NAME}-${arch}:${image_tags[0]}")
+        done
+
+        tags=()
+        for tag in "${image_tags[@]}"; do
+          tags+=("${REGISTRY_PREFIX}/${IMAGE_NAME}:${tag}")
+        done
+
+        tag_args=()
+        for tag in "${tags[@]}"; do
+          tag_args+=("--tag" "${tag}")
+        done
+
+        metadata_file="$(mktemp)"
+
+        docker buildx imagetools create \
+          --metadata-file "${metadata_file}" \
+          "${tag_args[@]}" \
+          "${source_images[@]}"
+
+        if [[ "${COSIGN}" == "true" ]]; then
+          digest="$(jq -r '.["containerimage.descriptor"].digest' "${metadata_file}")"
+          cosign sign --yes "${REGISTRY_PREFIX}/${IMAGE_NAME}@${digest}"
+        fi

--- a/.github/actions/publish-multi-arch-manifest/action.yml
+++ b/.github/actions/publish-multi-arch-manifest/action.yml
@@ -1,3 +1,4 @@
+# Forked from https://github.com/home-assistant/builder/blob/master/actions/publish-multi-arch-manifest/action.yml
 name: Publish multi-arch manifest
 description: Create a multi-arch manifest from per-architecture images and optionally sign it
 
@@ -67,6 +68,8 @@ runs:
 
         source_images=()
         for arch in $(jq -r '.[]' <<< "${ARCHITECTURES}"); do
+          # FIXME: upstream uses ${arch}-${IMAGE_NAME} but HA Supervisor resolves the {arch} placeholder
+          # in config.yaml image field and expects the suffix form: ${IMAGE_NAME}-${arch}
           source_images+=("${REGISTRY_PREFIX}/${IMAGE_NAME}-${arch}:${image_tags[0]}")
         done
 

--- a/.github/actions/publish-multi-arch-manifest/action.yml
+++ b/.github/actions/publish-multi-arch-manifest/action.yml
@@ -68,8 +68,7 @@ runs:
 
         source_images=()
         for arch in $(jq -r '.[]' <<< "${ARCHITECTURES}"); do
-          # FIXME: upstream uses ${arch}-${IMAGE_NAME} but HA Supervisor resolves the {arch} placeholder
-          # in config.yaml image field and expects the suffix form: ${IMAGE_NAME}-${arch}
+          # FIXME: previous versions used ${IMAGE_NAME}-${arch} but the new action does the reverse, we patch it here for backwards compatibility
           source_images+=("${REGISTRY_PREFIX}/${IMAGE_NAME}-${arch}:${image_tags[0]}")
         done
 

--- a/.github/workflows/build-addon.yaml
+++ b/.github/workflows/build-addon.yaml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Prepare build matrix
         id: matrix
-        uses: home-assistant/builder/actions/prepare-multi-arch-matrix@2026.03.2
+        uses: ./.github/actions/prepare-multi-arch-matrix
         with:
           architectures: ${{ steps.info.outputs.architectures }}
           image-name: ${{ steps.normalize.outputs.image_name }}
@@ -98,8 +98,11 @@ jobs:
       id-token: write
       packages: write
     steps:
+      - name: Check out the repository
+        uses: actions/checkout@v6
+
       - name: Publish multi-arch manifest
-        uses: home-assistant/builder/actions/publish-multi-arch-manifest@2026.03.2
+        uses: ./.github/actions/publish-multi-arch-manifest
         with:
           architectures: ${{ needs.prepare.outputs.architectures }}
           container-registry-password: ${{ secrets.GITHUB_TOKEN }}

--- a/rtsp-fixer/CHANGELOG.md
+++ b/rtsp-fixer/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.0.5
 
-Fix image name to use the multi-arch manifest directly, matching the new CI build naming convention.
+Fix CI image naming: fork upstream prepare/publish actions to restore the original {image}-{arch} per-arch image naming convention.
 
 ## 0.0.4
 

--- a/rtsp-fixer/CHANGELOG.md
+++ b/rtsp-fixer/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.0.5
 
-Fix CI image naming: fork upstream prepare/publish actions to restore the original {image}-{arch} per-arch image naming convention.
+Fix addon updates not being detected by HA Supervisor. The upstream builder actions changed per-arch image naming from `{image}-{arch}` to `{arch}-{image}`, breaking the match with the `{arch}` placeholder in config.yaml. Forked the actions locally to restore the original naming, and switched to a single multi-arch manifest image in config.yaml.
 
 ## 0.0.4
 

--- a/rtsp-fixer/CHANGELOG.md
+++ b/rtsp-fixer/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.0.5
 
-Fix addon updates not being detected by HA Supervisor. The upstream builder actions changed per-arch image naming from `{image}-{arch}` to `{arch}-{image}`, breaking the match with the `{arch}` placeholder in config.yaml. Forked the actions locally to restore the original naming, and switched to a single multi-arch manifest image in config.yaml.
+Fix addon update not being detected due to a change of how upstream actions build the Docker image name.
 
 ## 0.0.4
 

--- a/rtsp-fixer/CHANGELOG.md
+++ b/rtsp-fixer/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.5
+
+Fix image name to use the multi-arch manifest directly, matching the new CI build naming convention.
+
 ## 0.0.4
 
 Fix SIGSEGV crash when saving H264 thumbnails caused by stride-padded YCbCr buffers from openh264.

--- a/rtsp-fixer/config.yaml
+++ b/rtsp-fixer/config.yaml
@@ -4,7 +4,7 @@ version: "0.0.5"
 slug: "rtsp-stream-fixer"
 url: "https://github.com/LouisBrunner/ha-addons/blob/main/rtsp-fixer"
 init: false
-image: ghcr.io/louisbrunner/ha-rtsp-fixer-{arch}
+image: ghcr.io/louisbrunner/ha-rtsp-fixer
 arch:
   - aarch64
   - amd64

--- a/rtsp-fixer/config.yaml
+++ b/rtsp-fixer/config.yaml
@@ -4,7 +4,7 @@ version: "0.0.5"
 slug: "rtsp-stream-fixer"
 url: "https://github.com/LouisBrunner/ha-addons/blob/main/rtsp-fixer"
 init: false
-image: ghcr.io/louisbrunner/ha-rtsp-fixer
+image: ghcr.io/louisbrunner/ha-rtsp-fixer-{arch}
 arch:
   - aarch64
   - amd64

--- a/rtsp-fixer/config.yaml
+++ b/rtsp-fixer/config.yaml
@@ -1,10 +1,10 @@
 name: "RTSP Stream Fixer"
 description: "Fixes the non-standard RTSP streams so they can be used with FFMpeg"
-version: "0.0.4"
+version: "0.0.5"
 slug: "rtsp-stream-fixer"
 url: "https://github.com/LouisBrunner/ha-addons/blob/main/rtsp-fixer"
 init: false
-image: ghcr.io/louisbrunner/ha-rtsp-fixer-{arch}
+image: ghcr.io/louisbrunner/ha-rtsp-fixer
 arch:
   - aarch64
   - amd64


### PR DESCRIPTION
The upstream \`prepare-multi-arch-matrix\` and \`publish-multi-arch-manifest\` actions changed the per-arch image naming convention from \`{image}-{arch}\` to \`{arch}-{image}\`. This broke HA addon updates since Supervisor was looking for \`ha-rtsp-fixer-aarch64\` which no longer got pushed.

Fork both actions locally under \`.github/actions/\` with the one-line fix (\`\${IMAGE_NAME}-\${arch}\` instead of \`\${arch}-\${IMAGE_NAME}\`), and point \`build-addon.yaml\` at them.