### PR TITLE
fix(rtsp-fixer): skip upstream probe when camera is known offline

### DIFF
--- a/rtsp-fixer/server/pkg/proxy/client.go
+++ b/rtsp-fixer/server/pkg/proxy/client.go
@@ -85,6 +85,10 @@ func (me *client) Close() error {
 }
 
 func (me *client) Describe(url *base.URL) (*description.Session, *base.Response, error) {
+	if offline, offlineErr := me.srv.isOffline(me.path); offline {
+		me.srv.logger.Warnf("stream %q is known offline, skipping upstream probe", me.path)
+		return me.makeThumbnailStream(offlineErr)
+	}
 	session, resp, err := me.clt.Describe(url)
 	if err != nil {
 		return me.makeThumbnailStream(err)

--- a/rtsp-fixer/server/pkg/proxy/thumbnails.go
+++ b/rtsp-fixer/server/pkg/proxy/thumbnails.go
@@ -37,6 +37,18 @@ type thumbnailData struct {
 	lastCapture   time.Time
 	thumbnailPath string
 	thumbnail     image.Image
+	offline       bool
+	offlineErr    error
+}
+
+func (me *server) isOffline(path string) (bool, error) {
+	me.thumbsMutex.RLock()
+	defer me.thumbsMutex.RUnlock()
+	thumb, ok := me.thumbs[path]
+	if !ok {
+		return false, nil
+	}
+	return thumb.offline, thumb.offlineErr
 }
 
 func (me *server) shouldRecordThumbnail(path string) bool {
@@ -149,6 +161,12 @@ func (me *server) saveThumbnailInternal(path string, getImage func() (image.Imag
 
 func (me *client) makeThumbnailStream(originalErr error) (*description.Session, *base.Response, error) {
 	me.srv.logger.WithError(originalErr).Warnf("stream %q appears to be offline, creating thumbnail stream", me.path)
+	me.srv.thumbsMutex.Lock()
+	if thumb, ok := me.srv.thumbs[me.path]; ok {
+		thumb.offline = true
+		thumb.offlineErr = originalErr
+	}
+	me.srv.thumbsMutex.Unlock()
 	forma := &format.MJPEG{}
 	media := &description.Media{
 		Type:    description.MediaTypeVideo,
@@ -189,6 +207,12 @@ func (me *client) monitorUpstream() {
 			probe.Close()
 			if err == nil {
 				me.srv.logger.Infof("stream %q came back online, closing thumbnail stream", me.path)
+				me.srv.thumbsMutex.Lock()
+				if thumb, ok := me.srv.thumbs[me.path]; ok {
+					thumb.offline = false
+					thumb.offlineErr = nil
+				}
+				me.srv.thumbsMutex.Unlock()
 				me.Close()
 				return
 			}


### PR DESCRIPTION
When a camera is offline, new connections were still probing the dead upstream (4s timeout) before falling back to the thumbnail stream. With go2rtc's ffmpeg timeout at 5s, this left no time for SETUP+PLAY, causing `ERR [exec] timeout`.

- Track offline state in `thumbnailData` (set on first timeout, cleared when monitor detects camera back online)
- `Describe()` now short-circuits immediately for known-offline paths