### PR TITLE
feat(rtsp-fixer): improve offline detection and error thumbnail overlay (0.0.6)

### DIFF
--- a/rtsp-fixer/CHANGELOG.md
+++ b/rtsp-fixer/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.6
+
+Improve offline detection for streams and serve thumbnails with error feedback.
+
 ## 0.0.5
 
 Fix addon update not being detected due to a change of how upstream actions build the Docker image name.

--- a/rtsp-fixer/config.yaml
+++ b/rtsp-fixer/config.yaml
@@ -1,6 +1,6 @@
 name: "RTSP Stream Fixer"
 description: "Fixes the non-standard RTSP streams so they can be used with FFMpeg"
-version: "0.0.5"
+version: "0.0.6"
 slug: "rtsp-stream-fixer"
 url: "https://github.com/LouisBrunner/ha-addons/blob/main/rtsp-fixer"
 init: false

--- a/rtsp-fixer/server/pkg/proxy/client.go
+++ b/rtsp-fixer/server/pkg/proxy/client.go
@@ -17,6 +17,8 @@ import (
 	"github.com/pion/rtp"
 )
 
+const connTimeout = 4 * time.Second
+
 type thumbnailRecorder struct {
 	h264 *rtph264.Decoder
 }
@@ -54,8 +56,8 @@ func (me *server) createClientFor(path string) (*client, error) {
 			Scheme:       stream.URL.Scheme,
 			Host:         stream.URL.Host,
 			UserAgent:    userAgent,
-			ReadTimeout:  4 * time.Second,
-			WriteTimeout: 4 * time.Second,
+			ReadTimeout:  connTimeout,
+			WriteTimeout: connTimeout,
 		},
 		path:   path,
 		config: stream,
@@ -85,8 +87,20 @@ func (me *client) Close() error {
 }
 
 func (me *client) Describe(url *base.URL) (*description.Session, *base.Response, error) {
+	me.srv.thumbsMutex.RLock()
+	thumb, ok := me.srv.thumbs[me.path]
+	var connErr error
+	if ok {
+		connErr = thumb.connErr
+	}
+	me.srv.thumbsMutex.RUnlock()
+
+	if connErr != nil {
+		return me.makeThumbnailStream(connErr)
+	}
 	session, resp, err := me.clt.Describe(url)
 	if err != nil {
+		me.srv.updateConnErr(me.path, err)
 		return me.makeThumbnailStream(err)
 	}
 	return session, resp, err

--- a/rtsp-fixer/server/pkg/proxy/monitor.go
+++ b/rtsp-fixer/server/pkg/proxy/monitor.go
@@ -1,0 +1,113 @@
+package proxy
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/bluenviron/gortsplib/v4"
+	"github.com/bluenviron/gortsplib/v4/pkg/base"
+)
+
+type pubSub struct {
+	mu   sync.Mutex
+	subs map[string][]chan error
+}
+
+func newPubSub() *pubSub {
+	return &pubSub{subs: make(map[string][]chan error)}
+}
+
+func (me *pubSub) subscribe(path string) chan error {
+	ch := make(chan error, 1)
+	me.mu.Lock()
+	defer me.mu.Unlock()
+	me.subs[path] = append(me.subs[path], ch)
+	return ch
+}
+
+func (me *pubSub) unsubscribe(path string, ch chan error) {
+	me.mu.Lock()
+	defer me.mu.Unlock()
+	subs := me.subs[path]
+	for i, s := range subs {
+		if s == ch {
+			me.subs[path] = append(subs[:i], subs[i+1:]...)
+			break
+		}
+	}
+}
+
+func (me *pubSub) publish(path string, err error) {
+	me.mu.Lock()
+	defer me.mu.Unlock()
+	for _, ch := range me.subs[path] {
+		select {
+		case ch <- err:
+		default:
+		}
+	}
+}
+
+func (me *server) runMonitor(ctx context.Context) {
+	me.probeAll()
+	ticker := time.NewTicker(upstreamMonitorInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			me.probeAll()
+		}
+	}
+}
+
+func (me *server) probeAll() {
+	for path, stream := range me.streams {
+		go me.probeUpstream(path, stream)
+	}
+}
+
+func (me *server) probeUpstream(path string, cfg *StreamConfig) {
+	url := cfg.URL
+	probe := gortsplib.Client{
+		Scheme:       url.Scheme,
+		Host:         url.Host,
+		UserAgent:    userAgent,
+		ReadTimeout:  connTimeout,
+		WriteTimeout: connTimeout,
+	}
+	err := probe.Start2()
+	if err != nil {
+		me.updateConnErr(path, err)
+		return
+	}
+	defer probe.Close()
+	_, _, err = probe.Describe((*base.URL)(&url))
+	me.updateConnErr(path, err)
+}
+
+func (me *server) updateConnErr(path string, newErr error) {
+	me.thumbsMutex.Lock()
+	thumb, ok := me.thumbs[path]
+	if !ok {
+		me.thumbsMutex.Unlock()
+		return
+	}
+	oldErr := thumb.connErr
+	thumb.connErr = newErr
+	me.thumbsMutex.Unlock()
+
+	wasOffline := oldErr != nil
+	isOfflineNow := newErr != nil
+	if wasOffline == isOfflineNow {
+		return
+	}
+	if newErr == nil {
+		me.logger.Infof("stream %q came back online", path)
+	} else {
+		me.logger.WithError(newErr).Warnf("stream %q went offline", path)
+	}
+	me.pubSub.publish(path, newErr)
+}

--- a/rtsp-fixer/server/pkg/proxy/server.go
+++ b/rtsp-fixer/server/pkg/proxy/server.go
@@ -42,6 +42,7 @@ type server struct {
 	streams     map[string]*StreamConfig
 	thumbsMutex sync.RWMutex
 	thumbs      map[string]*thumbnailData
+	pubSub      *pubSub
 }
 
 func NewServer(logger *logrus.Logger, baseFolder, port, httpPort string, streams []StreamConfig) (*server, error) {
@@ -70,6 +71,7 @@ func NewServer(logger *logrus.Logger, baseFolder, port, httpPort string, streams
 		logger:  logger,
 		streams: streamsMap,
 		thumbs:  thumbsMap,
+		pubSub:  newPubSub(),
 	}
 	me.rtsp = &gortsplib.Server{
 		Handler:     me,
@@ -91,6 +93,7 @@ func (me *server) Run(ctx context.Context) error {
 		me.rtsp.Close()
 		me.httpSrv.Close()
 	}()
+	go me.runMonitor(ctx)
 	go func() {
 		me.logger.Infof("starting HTTP thumbnail server on %s", me.httpSrv.Addr)
 		err := me.httpSrv.ListenAndServe()

--- a/rtsp-fixer/server/pkg/proxy/thumbnails.go
+++ b/rtsp-fixer/server/pkg/proxy/thumbnails.go
@@ -15,7 +15,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/bluenviron/gortsplib/v4"
 	"github.com/bluenviron/gortsplib/v4/pkg/base"
 	"github.com/bluenviron/gortsplib/v4/pkg/description"
 	"github.com/bluenviron/gortsplib/v4/pkg/format"
@@ -37,6 +36,7 @@ type thumbnailData struct {
 	lastCapture   time.Time
 	thumbnailPath string
 	thumbnail     image.Image
+	connErr       error
 }
 
 func (me *server) shouldRecordThumbnail(path string) bool {
@@ -56,6 +56,12 @@ func (me *server) serveThumbnail(w http.ResponseWriter, r *http.Request) {
 
 	me.thumbsMutex.RLock()
 	thumb, ok := me.thumbs[path]
+	var img image.Image
+	var connErr error
+	if ok {
+		img = thumb.thumbnail
+		connErr = thumb.connErr
+	}
 	me.thumbsMutex.RUnlock()
 
 	if !ok {
@@ -65,10 +71,12 @@ func (me *server) serveThumbnail(w http.ResponseWriter, r *http.Request) {
 
 	me.logger.Debugf("serving thumbnail for %q", path)
 
-	img := thumb.thumbnail
 	if img == nil {
 		me.logger.Warnf("thumbnail for %q not found, using black placeholder", path)
 		img = getFallbackThumbnail()
+	}
+	if connErr != nil {
+		img = overlayError(img, connErr)
 	}
 
 	w.Header().Set("Content-Type", "image/jpeg")
@@ -161,45 +169,12 @@ func (me *client) makeThumbnailStream(originalErr error) (*description.Session, 
 		originalErr: originalErr,
 		media:       media,
 	}
-	go me.monitorUpstream()
 	return desc, &base.Response{StatusCode: base.StatusOK}, nil
-}
-
-func (me *client) monitorUpstream() {
-	ticker := time.NewTicker(upstreamMonitorInterval)
-	defer ticker.Stop()
-	url := me.config.URL
-	for {
-		select {
-		case <-me.ctx.Done():
-			return
-		case <-ticker.C:
-			probe := gortsplib.Client{
-				Scheme:       url.Scheme,
-				Host:         url.Host,
-				UserAgent:    userAgent,
-				ReadTimeout:  4 * time.Second,
-				WriteTimeout: 4 * time.Second,
-			}
-			err := probe.Start2()
-			if err != nil {
-				continue
-			}
-			_, _, err = probe.Describe((*base.URL)(&url))
-			probe.Close()
-			if err == nil {
-				me.srv.logger.Infof("stream %q came back online, closing thumbnail stream", me.path)
-				me.Close()
-				return
-			}
-			me.srv.logger.WithError(err).Debugf("stream %q still offline", me.path)
-		}
-	}
 }
 
 func (me *client) playThumbnailStream() (*base.Response, error) {
 	img, err := me.srv.getThumbnail(me.path)
-	if err != nil {
+	if img == nil {
 		me.srv.logger.WithError(err).Warnf("no thumbnail for %q, using black placeholder", me.path)
 		img = getFallbackThumbnail()
 	}
@@ -217,19 +192,32 @@ func (me *client) playThumbnailStream() (*base.Response, error) {
 	}
 
 	jpegBytes := buf.Bytes()
+	ch := me.srv.pubSub.subscribe(me.path)
 	go func() {
+		defer me.srv.pubSub.unsubscribe(me.path, ch)
 		ticker := time.NewTicker(time.Second)
 		defer ticker.Stop()
 
-		for range ticker.C {
-			pkts, err := enc.Encode(jpegBytes)
-			if err != nil {
-				me.srv.logger.WithError(err).Errorf("thumbnail: failed to encode MJPEG frame")
+		for {
+			select {
+			case <-me.ctx.Done():
 				return
-			}
-			for _, pkt := range pkts {
-				if err = me.stream.WritePacketRTP(me.thumbnailStream.media, pkt); err != nil {
+			case connErr := <-ch:
+				if connErr == nil {
+					me.srv.logger.Infof("stream %q came back online, closing thumbnail stream", me.path)
+					me.Close()
 					return
+				}
+			case <-ticker.C:
+				pkts, err := enc.Encode(jpegBytes)
+				if err != nil {
+					me.srv.logger.WithError(err).Errorf("thumbnail: failed to encode MJPEG frame")
+					return
+				}
+				for _, pkt := range pkts {
+					if err = me.stream.WritePacketRTP(me.thumbnailStream.media, pkt); err != nil {
+						return
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

- Server-wide monitor probes all streams in parallel every 10s, replacing the old per-client monitor that died when the client disconnected
- Offline state (`connErr`) stored centrally; clients skip upstream probe when stream is known offline
- Pub/sub notifies thumbnail stream clients to close the moment a camera comes back online
- HTTP thumbnail endpoint overlays the connection error on the image
- Fix nil panic when serving thumbnail stream before any thumbnail has been captured

## Test plan

- [x] Start server with camera off → immediately detected offline, clients get thumbnail stream with error overlay
- [x] Camera comes online → pub/sub closes all thumbnail stream clients
- [x] Start server with camera on → no offline detection, live stream proxied normally
- [x] Camera goes offline while server running → monitor detects transition within 10s