### PR TITLE
feat(thumbnails): POST endpoint to reset capture timeout (0.0.8)

### DIFF
--- a/rtsp-fixer/CHANGELOG.md
+++ b/rtsp-fixer/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.8
+
+Add POST endpoint on the thumbnail URI to reset the capture timeout, forcing a new screenshot on the next frame.
+
 ## 0.0.7
 
 Fix race condition when saving thumbnails and properly give timestamps in the thumbnail stream (ffmpeg compatibility).

--- a/rtsp-fixer/config.yaml
+++ b/rtsp-fixer/config.yaml
@@ -1,6 +1,6 @@
 name: "RTSP Stream Fixer"
 description: "Fixes the non-standard RTSP streams so they can be used with FFMpeg"
-version: "0.0.7"
+version: "0.0.8"
 slug: "rtsp-stream-fixer"
 url: "https://github.com/LouisBrunner/ha-addons/blob/main/rtsp-fixer"
 init: false

--- a/rtsp-fixer/server/pkg/proxy/server.go
+++ b/rtsp-fixer/server/pkg/proxy/server.go
@@ -78,7 +78,8 @@ func NewServer(logger *logrus.Logger, baseFolder, port, httpPort string, streams
 		RTSPAddress: fmt.Sprintf(":%s", port),
 	}
 	mux := http.NewServeMux()
-	mux.HandleFunc("/", me.serveThumbnail)
+	mux.HandleFunc("GET /", me.serveThumbnail)
+	mux.HandleFunc("POST /", me.resetThumbnail)
 	me.httpSrv = &http.Server{
 		Addr:    fmt.Sprintf(":%s", httpPort),
 		Handler: mux,

--- a/rtsp-fixer/server/pkg/proxy/thumbnails.go
+++ b/rtsp-fixer/server/pkg/proxy/thumbnails.go
@@ -54,9 +54,32 @@ func (me *server) shouldRecordThumbnail(path string) bool {
 	return true
 }
 
+func thumbnailPath(r *http.Request) string {
+	return fmt.Sprintf("/%s", strings.TrimPrefix(r.URL.Path, "/"))
+}
+
+func (me *server) resetThumbnail(w http.ResponseWriter, r *http.Request) {
+	path := thumbnailPath(r)
+
+	me.thumbsMutex.Lock()
+	thumb, ok := me.thumbs[path]
+	if ok {
+		thumb.lastCapture = time.Time{}
+		me.thumbs[path] = thumb
+	}
+	me.thumbsMutex.Unlock()
+
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+
+	me.logger.Infof("thumbnail timeout reset for %q", path)
+	w.WriteHeader(http.StatusNoContent)
+}
+
 func (me *server) serveThumbnail(w http.ResponseWriter, r *http.Request) {
-	name := strings.TrimPrefix(r.URL.Path, "/")
-	path := fmt.Sprintf("/%s", name)
+	path := thumbnailPath(r)
 
 	me.thumbsMutex.RLock()
 	thumb, ok := me.thumbs[path]


### PR DESCRIPTION
POST on the thumbnail URI resets `lastCapture` to zero, so the next IDR frame is captured immediately instead of waiting for the 5-minute interval.

Returns `204 No Content` on success, `404` if the stream is unknown.